### PR TITLE
Ensures consistency in RC channel names and fixes calendar bug

### DIFF
--- a/static/js/add-to-calendar.js
+++ b/static/js/add-to-calendar.js
@@ -170,12 +170,14 @@
         startTime = formatTime(event.tzstart);
         endTime = formatTime(event.tzend);
       }
-      
+
+      // We remove everything in the URL after '#' because it otherwise breaks
+      // the calendar data
       var cal = [
           'BEGIN:VCALENDAR',
           'VERSION:2.0',
           'BEGIN:VEVENT',
-          'URL:' + document.URL,
+          'URL:' + document.URL.split('#')[0],
           'DTSTART:' + (startTime || ''),
           'DTEND:' + (endTime || ''),
           'SUMMARY:' + (event.title || ''),
@@ -184,14 +186,13 @@
           'UID:' + (event.id || '') + '-' + document.URL,
           'END:VEVENT',
           'END:VCALENDAR'].join('\n');
-          
+
       if (ieMustDownload) {
         return '<a class="' + eClass + '" onclick="ieDownloadCalendar(\'' +
           escapeJSValue(cal) + '\')">' + calendarName + '</a>';
       }
       
       var href = encodeURI('data:text/calendar;charset=utf8,' + cal);
-      
       return '<a class="' + eClass + '" download="'+CONFIG.texts.download+'" href="' + 
         href + '">' + calendarName + '</a>';
      

--- a/templates/paper.html
+++ b/templates/paper.html
@@ -170,17 +170,22 @@
 <div class="tab-content" id="myTabContent">
   <div class="tab-pane fade show active" id="chat" role="tabpanel" aria-labelledby="chat-tab">
 {% if config.enable_chat %}
+{% if paper.rocketchat_channel[6:15] == 'tutorials' %}
+  {% set rocketchat = paper.rocketchat_channel[6:14] + paper.rocketchat_channel[15:] %}
+{% else %}
+  {% set rocketchat = paper.rocketchat_channel %}
+{% endif %}
 <div class="container" style="background-color:white; padding: 0px;">
   <div class="text-muted text-center">
     You can open the
-    <a href="https://{{config.chat_server}}/channel/{{paper.rocketchat_channel}}"
-       target="_blank">#{{paper.rocketchat_channel}}</a>
+    <a href="https://{{config.chat_server}}/channel/{{rocketchat}}"
+       target="_blank">#{{rocketchat}}</a>
     channel in a separate window.
   </div>
 
   <!-- Chat -->
     <div id="gitter" class="slp">
-      <iframe frameborder="0" src="https://{{config.chat_server}}/channel/{{paper.rocketchat_channel}}?layout=embedded" height="700px" width="100%" ></iframe>
+      <iframe frameborder="0" src="https://{{config.chat_server}}/channel/{{rocketchat}}?layout=embedded" height="700px" width="100%" ></iframe>
     </div>
 </div>
 {% endif %}

--- a/templates/plenary_session.html
+++ b/templates/plenary_session.html
@@ -65,10 +65,24 @@
   {% if plenary_session.videos != none %}
 
   {% if plenary_session.rocketchat_channel is defined %}
+  <!-- We follow the RC IDs in the main conference -->
+  {% if plenary_session.id == 'two-paths-to-intelligence' %}
+    {% set rocketchat_fixed = 'paper-event_keynote-1_-geoffrey-hinton' %}
+  {% elif plenary_session.id == 'acl-rolling-review-update-and-discussion' %}
+    {% set rocketchat_fixed = 'paper-event_arr-discussion' %}
+  {% elif plenary_session.id == 'memorial' %}
+    {% set rocketchat_fixed = 'paper-event_drago-memorial' %}
+  {% elif plenary_session.id == 'the-future-of-computational-linguistics-in-the-llm-age' %}
+    {% set rocketchat_fixed = 'paper-event_plenary_-llm-panel' %}
+  {% elif plenary_session.id == 'large-language-models-as-cultural-technologies_-imitation-and-innovation-in-children-and-models' %}
+    {% set rocketchat_fixed = 'paper-event_keynote-2_-alison-gopnik' %}
+  {% else %}
+    {% set rocketchat_fixed = plenary_session.id %}
+  {% endif %}
   <div class="text-muted text-center">
     You can open the
-    <a href="https://{{config.chat_server}}/channel/{{plenary_session.rocketchat_channel}}"
-       target="_blank">#{{ plenary_session.rocketchat_channel }}
+    <a href="https://{{config.chat_server}}/channel/{{rocketchat_fixed}}"
+       target="_blank">#{{ rocketchat_fixed }}
     </a>
     channel below in a separate window.
   </div>

--- a/templates/plenary_session.html
+++ b/templates/plenary_session.html
@@ -8,7 +8,6 @@
     <h2 class="card-title main-title text-center" style="color:black">
       {{plenary_session.title}}
     </h2>
-      {{plenary_session}}
     {% if plenary_session.presenter != none %}
     <h3 class="card-subtitle mb-2 text-muted text-center">
       {{plenary_session.presenter}}

--- a/templates/tutorial.html
+++ b/templates/tutorial.html
@@ -107,7 +107,6 @@
       Pre-recorded Video
     </a>
     {% endif %}
-
     <a class="btn btn-outline-danger"
        href="https://{{config.chat_server}}/channel/{{tutorial.rocketchat_channel}}"
        target="_blank"


### PR DESCRIPTION
This commit ensures that RC channel names are the same for events when arriving either via paper (from the list of papers) or via event (from the calendar).

It also fixes a bug with iCal calendars where some URLs containing '#' would break the calendar format.