### PR TITLE
Overall improvements to the plenaries pages

### DIFF
--- a/acl_miniconf/import_acl2023.py
+++ b/acl_miniconf/import_acl2023.py
@@ -61,6 +61,7 @@ UNDERLINE_EVENTS_TO_SKIP = {
     "15246",
     "15270",
     "15247",
+    "15247",  # Ethics Panel, which is a duplicate
     # Spotlights
     "15510",
     "15511",

--- a/acl_miniconf/load_site_data.py
+++ b/acl_miniconf/load_site_data.py
@@ -319,15 +319,15 @@ def reformat_plenary_data(plenaries):
         )
         # Load images if we have one
         if plenary_key == "memorial":
-            plenary.image_url = "drago.jpg"
+            plenary.image_url = "invited/drago.jpg"
         elif plenary_key == "two-paths-to-intelligence":
-            plenary.image_url = "invited1.jpg"
+            plenary.image_url = "invited/invited1.jpg"
         elif plenary_key[:10] == "large-lang":
-            plenary.image_url = "invited2.jpg"
+            plenary.image_url = "invited/invited2.jpg"
         elif plenary_key[:10] == "the-future":
-            plenary.image_url = "invited3.jpg"
+            plenary.image_url = "invited/invited3.jpg"
         else:
-            plenary.image_url = None
+            plenary.image_url = 'acl2023/acl-logo.png'
         # Add the existing dates to a list of all possible dates
         if plenary_day not in session_data:
             session_data[plenary_day] = []

--- a/acl_miniconf/load_site_data.py
+++ b/acl_miniconf/load_site_data.py
@@ -327,7 +327,7 @@ def reformat_plenary_data(plenaries):
         elif plenary_key[:10] == "the-future":
             plenary.image_url = "invited/invited3.jpg"
         else:
-            plenary.image_url = 'acl2023/acl-logo.png'
+            plenary.image_url = "acl2023/acl-logo.png"
         # Add the existing dates to a list of all possible dates
         if plenary_day not in session_data:
             session_data[plenary_day] = []
@@ -338,7 +338,7 @@ def reformat_plenary_data(plenaries):
 
     # Sorting days like this only works in this very specific case.
     session_day_data.sort()
-    session_day_data = list(
-        map(lambda x: (x[0], x[1], True), enumerate(session_day_data))
-    )
+    session_day_data = [
+        (f"jul1{idx}", day, idx == 0) for idx, day in enumerate(session_day_data)
+    ]
     return session_data, session_day_data

--- a/templates/components.html
+++ b/templates/components.html
@@ -35,38 +35,48 @@
       <div class="row">
         <div class="col-md-2 col-sm-5">
           {% if plenary_session.image_url is not none %}
-          <img src="static/images/invited/{{plenary_session.image_url}}" width="100%" class="mt-3" />
+          <img src="static/images/{{plenary_session.image_url}}" width="100%" class="mt-3" />
           {% endif %}
         </div>
 
-        {% if plenary_session.presenter != none %}
-        <div class="m-3 text-muted">
-          <span class="card-title h3">
+        <div class="col-md-10 col-sm-6">
+          <div class="m-3 text-muted">
+            <h4>
+            <a href="plenary_session_{{plenary_session.id}}.html" class="main-title" >
+              {{plenary_session.title}}
+            </a>
+            </h4>
+          </div>
+
+          {% if plenary_session.presenter != none %}
+          <div class="m-3 text-muted">
+            <span class="card-title h3">
               {{plenary_session.presenter}}
               {% if plenary_session.institution != none %}
               / {{plenary_session.institution}}
               {% endif %}
-          </span>
-        </div>
-        {% endif %}
-
-        {% for session in plenary_session.sessions %}
-          <div class="m-3 text-muted">
-            {{session.session}}
-            <span class="session_times">{{session.time_string}}</span>
-              {% if plenary_session.presentation_id or session.presentation_id %}
-              [<a href="plenary_session_{{plenary_session.id}}.html" class="card-link">Watch video</a>]
-              {% else %}
-              [<a href="livestream.html" class="card-link">Join Livestream</a>]
-              {% endif %}
+            </span>
           </div>
-        {% endfor %}
+          {% endif %}
 
-        {% if plenary_session.abstract != none %}
-        <div class="m-3">
-          {{plenary_session.abstract|markdown}}
+          {% for session in plenary_session.sessions %}
+            <div class="m-3 text-muted">
+              {{session.session}}
+              <span class="session_times">{{session.time_string}}</span>
+                {% if plenary_session.presentation_id or session.presentation_id %}
+                [<a href="plenary_session_{{plenary_session.id}}.html" class="card-link">Watch video</a>]
+                {% else %}
+                [<a href="livestream.html" class="card-link">Join Livestream</a>]
+                {% endif %}
+            </div>
+          {% endfor %}
+
+          {% if plenary_session.abstract != none %}
+          <div class="m-3">
+            {{plenary_session.abstract|markdown}}
+          </div>
+          {% endif %}
         </div>
-        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR adds better interactions with Plenaries:

  * It changes the internal names of tabs to direct users directly to their chosen plenary day instead of a general list
  * Adds an event to the 'exclude' list because it is currently being shown twice, once as BoF and once as Plenary
  * Adds ACL logo images to the Plenaries without a specific picture
  * Fixes a bug where talk titles weren't being shown correctly.