### PR TITLE
Makes the RC window bigger for plenaries

### DIFF
--- a/templates/plenary_session.html
+++ b/templates/plenary_session.html
@@ -87,7 +87,7 @@
   </div>
 
   <div class="row m-2">
-    <div class="col-md-7 col-xs-12 p-2">
+    <!--<div class="col-md-7 col-xs-12 p-2">
     <div id="accordion">
       {% for video in plenary_session.videos %}
       <div class="row m-2">
@@ -102,9 +102,10 @@
       </div>
       {% endfor %}
     </div>
-    </div>
+    </div>-->
 
-    <div class="col-md-5 col-xs-12 p-2">
+    <!--<div class="col-md-5 col-xs-12 p-2">-->
+    <div class="container">
       <div id="gitter" class="slp">
         <iframe frameborder="0" src="https://{{config.chat_server}}/channel/{{rocketchat_fixed}}?layout=embedded" height="700px" width="100%" ></iframe>
       </div>


### PR DESCRIPTION
The current RC window for plenaries leaves room for a video. Since that's taking place in Underline, this PR increases the RC window to use that space.