### PR TITLE
Changes the "socials" page to reflect the newly-assigned RocketChat channels

### DIFF
--- a/templates/socials.html
+++ b/templates/socials.html
@@ -96,7 +96,13 @@
       </p>
       {% endif %}
       <p class="text-center text-muted card-title">
-      {% if socials[social]['events'][event]['id'][0] != 'b' %}
+      {% if socials[social]['events'][event]['track'] == 'Queer in AI workshop' %}
+        <!-- Unifies two related events into one -->
+        <a href="https://acl.rocket.chat/channel/paper-birds-of-a-feather-1" target="_blank"> Chat </a>  
+      {% elif socials[social]['events'][event]['id'][:9] == 'diversity' %}
+        <!-- Unifies two related events into one -->
+        <a href="https://acl.rocket.chat/channel/paper-event_diversity-and-inclusion" target="_blank"> Chat </a>  
+      {% elif socials[social]['events'][event]['id'][0] != 'b' %}
         <a href="https://acl.rocket.chat/channel/paper-event_{{socials[social]['events'][event]['id']}}" target="_blank"> Chat </a>  
       {% else %}
         <a href="https://acl.rocket.chat/channel/paper-{{socials[social]['events'][event]['id']}}" target="_blank"> Chat </a>  


### PR DESCRIPTION
This commit unifies some events into a single RC channel, as it doesn't make any sense to have two channels for the same events just because the event has two sessions.