### PR TITLE
Fixes a text description that doesn't match the current time for an event

### DIFF
--- a/data/acl_2023/data/booklet_data.json
+++ b/data/acl_2023/data/booklet_data.json
@@ -75,7 +75,7 @@
     {
       "id": "navigating-nlp-in-the-era-of-llm",
       "title": "Navigating NLP in the Era of Large Language Models",
-      "desc": "Join us for a panel featuring experts Sara Hooker (Cohere), Swaroop Mishra (Google DeepMind), and Danqi Chen (Princeton), who will provide invaluable insights into navigating the tempestuous seas of NLP in the era of large language models. This discussion will guide students and early career researchers through impactful directions, progress-making strategies, offering perspectives from academia and industry.\n\nTuesday, July 11 - Time: 11:45–12:30 EDT\n\nRoom: Pier 2&3",
+      "desc": "Join us for a panel featuring experts Sara Hooker (Cohere), Swaroop Mishra (Google DeepMind), and Danqi Chen (Princeton), who will provide invaluable insights into navigating the tempestuous seas of NLP in the era of large language models. This discussion will guide students and early career researchers through impactful directions, progress-making strategies, offering perspectives from academia and industry.\n\nTuesday, July 11 - Time: 13:45–14:30 EDT\n\nRoom: Pier 2&3",
       "location": "Pier 2\\&3",
       "start_time": "2023-07-11T13:45:00",
       "end_time": "2023-07-11T14:30:00",


### PR DESCRIPTION
A written description used to refer to an event time that is no longer accurate.