### PR TITLE
Changes an internal key to ensure that day tabs for sessions work correctly

### DIFF
--- a/acl_miniconf/data.py
+++ b/acl_miniconf/data.py
@@ -189,7 +189,11 @@ class Session(BaseModel):
 
     @property
     def day(self) -> str:
-        return self.start_time.astimezone(pytz.utc).strftime("%B %d")
+        # This line was changed because the .js library that builds the calendar
+        # expects the dates to have the second format. If we do it the previous
+        # way, the `sessions.html` tabs for each day don't work well.
+        # return self.start_time.astimezone(pytz.utc).strftime("%B %d")
+        return self.start_time.astimezone(pytz.utc).strftime("%b %d")
 
     @property
     def time_string(self) -> str:


### PR DESCRIPTION
When clicking on a session in the Schedule you are taken to the Sessions page which contains tabs. This commit fixes an issue where the proper tab would not be shown because it would redirect users to a page ending in '#july11' when it was actually expecting '#jul11'